### PR TITLE
Using ruby blocks when calling into javascript functions

### DIFF
--- a/mrblib/mrubyjs.rb
+++ b/mrblib/mrubyjs.rb
@@ -46,12 +46,13 @@ module MrubyJs
     # 3. If args is not empty, we will fetch the function and make the call
     # Our solution here only covers the most common cases, users
     # will need to explicitly use call or get for other rare cases
-    def method_missing(key, *args)
+    def method_missing(key, *args, &block)
       key = key.to_s
       if key[-1] == '='
         # This is a set method
         set(key[0..-2], *args)
       else
+        args.push(Proc.new(&block)) if block
         return call(key, *args) if args.length > 0
         get(key)
       end


### PR DESCRIPTION
This change makes it possible to use ruby block syntax when calling into javascript functions. 

It is accomplished by checking if a block is present and wrapping it in a proc.

example usage:

``` ruby
MrubyJs.global.instance_eval do
  jQuery('body').clicked do
     # stuff here
  end
end
```

thoughts?
